### PR TITLE
Upgrade GitHub Actions Checkout Step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Configure SSH
         run: |


### PR DESCRIPTION
Update the Checkout step to use the latest version of the GitHub checkout action to remove Node 16 dependencies.

Jira: [TEC-192]

[TEC-192]: https://acquired.atlassian.net/browse/TEC-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ