### PR TITLE
FEAT 1.0.2 Payment Intents

### DIFF
--- a/Api/Data/PaymentIntentInterface.php
+++ b/Api/Data/PaymentIntentInterface.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Acquired.com Payments Integration for Magento2
+ *
+ * Copyright (c) 2024 Acquired Limited (https://acquired.com/)
+ *
+ * This file is open source under the MIT license.
+ * Please see LICENSE file for more details.
+ */
+
+namespace Acquired\Payments\Api\Data;
+
+interface PaymentIntentInterface
+{
+    public const PAYMENT_INTENT_ID = 'payment_intent_id';
+    public const QUOTE_ID = 'quote_id';
+    public const SESSION_ID = 'session_id';
+    public const NONCE = 'nonce';
+    public const FINGERPRINT = 'fingerprint';
+    public const FINGERPRINT_DATA = 'fingerprint_data';
+    public const CREATED_AT = 'created_at';
+    public const UPDATED_AT = 'updated_at';
+
+    /**
+     * Set Payment Intent Id
+     *
+     * @param string $paymentIntentId
+     * @return void
+     */
+    public function setPaymentIntentId(string $paymentIntentId): void;
+
+    /**
+     * Get Payment Intent Id
+     *
+     * @return int|null
+     */
+    public function getPaymentIntentId(): ?int;
+
+    /**
+     * Set Quote Id
+     *
+     * @param int $quoteId
+     * @return void
+     */
+    public function setQuoteId(int $quoteId): void;
+
+    /**
+     * Get Quote Id
+     *
+     * @return int|null
+     */
+    public function getQuoteId(): ?int;
+
+    /**
+     * Set Session Id
+     *
+     * @param string $sessionId
+     * @return void
+     */
+    public function setSessionId(string $sessionId): void;
+
+    /**
+     * Get Session Id
+     *
+     * @return string|null
+     */
+    public function getSessionId(): ?string;
+
+    /**
+     * Set Nonce
+     *
+     * @param string|null $nonce
+     */
+    public function setNonce(?string $nonce): void;
+
+    /**
+     * Get Nonce
+     *
+     * @return string|null
+     */
+    public function getNonce(): ?string;
+
+    /**
+     * Set Fingerprint
+     *
+     * @param string $fingerprint
+     */
+    public function setFingerprint(string $fingerprint): void;
+
+    /**
+     * Get Fingerprint
+     *
+     * @return string|null
+     */
+    public function getFingerprint(): ?string;
+
+    /**
+     * Set Fingerprint Data
+     *
+     * @param string $fingerprintData
+     */
+    public function setFingerprintData(string $fingerprintData): void;
+
+    /**
+     * Get Fingerprint Data
+     *
+     * @return string|null
+     */
+    public function getFingerprintData(): ?string;
+
+    /**
+     * Get Created At
+     *
+     * @return string|null
+     */
+    public function getCreatedAt(): ?string;
+
+    /**
+     * Get Updated At
+     *
+     * @return string|null
+     */
+    public function getUpdatedAt(): ?string;
+}

--- a/Api/SessionInterface.php
+++ b/Api/SessionInterface.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace Acquired\Payments\Api;
 
 use Acquired\Payments\Api\Data\SessionDataInterface;
+use Acquired\Payments\Exception\Api\SessionException;
 
 interface SessionInterface
 {
     /**
      * Create a checkout session with acquired
      *
-     * @param string nonce
+     * @param string $nonce
      * @param mixed $customData
      * @return SessionDataInterface
      */
@@ -29,7 +30,7 @@ interface SessionInterface
     /**
      * Update checkout session data
      *
-     * @param string nonce
+     * @param string $nonce
      * @param string $sessionId
      * @param mixed $customData
      * @return SessionDataInterface
@@ -45,6 +46,4 @@ interface SessionInterface
      * @return void
      */
     public function prepareForPurchase(string $nonce) : void;
-
-
 }

--- a/Block/Adminhtml/Order/Payment/Form.php
+++ b/Block/Adminhtml/Order/Payment/Form.php
@@ -15,7 +15,6 @@ namespace Acquired\Payments\Block\Adminhtml\Order\Payment;
 
 use Exception;
 use Psr\Log\LoggerInterface;
-use Acquired\Payments\Api\SessionInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Payment\Block\Form\Cc;
@@ -32,7 +31,6 @@ class Form extends Cc
      * @param Context $context
      * @param Config $paymentConfig
      * @param SerializerInterface $serializer
-     * @param SessionInterface $acquiredSession
      * @param Basic $basicConf
      * @param CardConfig $cardConf
      * @param LoggerInterface $logger
@@ -42,7 +40,6 @@ class Form extends Cc
         Context $context,
         Config $paymentConfig,
         private readonly SerializerInterface $serializer,
-        private readonly SessionInterface $acquiredSession,
         private readonly Basic $basicConf,
         private readonly CardConfig $cardConf,
         private readonly LoggerInterface $logger,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable release changes to this project will be documented in this file.
 
+## [1.0.2] - Release Version
+- Introduce payment intent table to store payment intents from customers
+- Remove saving nonce and session id values to checkout session
+- Add saving nonce and session id as payment intents to separate database table
+
 ## [1.0.0] - Release Version
 - Fix race condition breaking payment process
 - Fix order id not being set properly for saved cards

--- a/Controller/Adminhtml/Session/Confirm.php
+++ b/Controller/Adminhtml/Session/Confirm.php
@@ -25,19 +25,19 @@ use Acquired\Payments\Api\SessionInterface;
 class Confirm extends Action implements CsrfAwareActionInterface, HttpPostActionInterface
 {
     /**
-     * @var \Magento\Framework\Controller\Result\JsonFactory
+     * @var JsonFactory
      */
     protected $resultJsonFactory;
 
     /**
-     * @var \Acquired\Payments\Api\SessionInterface
+     * @var SessionInterface
      */
     protected $acquiredSession;
 
     /**
      * @param Context $context
      * @param JsonFactory $resultJsonFactory
-     * @param acquiredSession $acquiredSession
+     * @param SessionInterface $acquiredSession
      */
     public function __construct(
         Context $context,

--- a/Controller/Adminhtml/Session/Init.php
+++ b/Controller/Adminhtml/Session/Init.php
@@ -25,19 +25,19 @@ use Acquired\Payments\Api\SessionInterface;
 class Init extends Action implements CsrfAwareActionInterface, HttpPostActionInterface
 {
     /**
-     * @var \Magento\Framework\Controller\Result\JsonFactory
+     * @var JsonFactory
      */
     protected $resultJsonFactory;
 
     /**
-     * @var \Acquired\Payments\Api\SessionInterface
+     * @var SessionInterface
      */
     protected $acquiredSession;
 
     /**
      * @param Context $context
      * @param JsonFactory $resultJsonFactory
-     * @param acquiredSession $acquiredSession
+     * @param SessionInterface $acquiredSession
      */
     public function __construct(
         Context $context,

--- a/Controller/Adminhtml/Session/Update.php
+++ b/Controller/Adminhtml/Session/Update.php
@@ -25,19 +25,19 @@ use Acquired\Payments\Api\SessionInterface;
 class Update extends Action implements CsrfAwareActionInterface, HttpPostActionInterface
 {
     /**
-     * @var \Magento\Framework\Controller\Result\JsonFactory
+     * @var JsonFactory
      */
     protected $resultJsonFactory;
 
     /**
-     * @var \Acquired\Payments\Api\SessionInterface
+     * @var SessionInterface
      */
     protected $acquiredSession;
 
     /**
      * @param Context $context
      * @param JsonFactory $resultJsonFactory
-     * @param acquiredSession $acquiredSession
+     * @param SessionInterface $acquiredSession
      */
     public function __construct(
         Context $context,

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -15,7 +15,7 @@ use Magento\Framework\App\ProductMetadataInterface;
 
 class Config
 {
-    public static $version = "1.0.0";
+    public static $version = "1.0.2";
 
     public function __construct(
         private readonly ProductMetadataInterface $productMetadata

--- a/Model/Payment/Intent.php
+++ b/Model/Payment/Intent.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Acquired.com Payments Integration for Magento2
+ *
+ * Copyright (c) 2024 Acquired Limited (https://acquired.com/)
+ *
+ * This file is open source under the MIT license.
+ * Please see LICENSE file for more details.
+ */
+
+namespace Acquired\Payments\Model\Payment;
+
+use Acquired\Payments\Api\Data\PaymentIntentInterface;
+use Acquired\Payments\Model\ResourceModel\Payment\Intent as ResourceModel;
+use Magento\Framework\Model\AbstractModel;
+
+class Intent extends AbstractModel implements PaymentIntentInterface
+{
+    /**
+     * @var string
+     */
+    protected $_eventPrefix = 'acquired_payment_intent';
+
+    /**
+     * @inheritdoc
+     */
+    protected function _construct()
+    {
+        $this->_init(ResourceModel::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setPaymentIntentId(string $paymentIntentId): void
+    {
+        $this->setData(self::PAYMENT_INTENT_ID, $paymentIntentId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPaymentIntentId(): ?int
+    {
+        return (int) $this->_getData(self::PAYMENT_INTENT_ID) ?: null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setQuoteId(int $quoteId): void
+    {
+        $this->setData(self::QUOTE_ID, $quoteId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getQuoteId(): ?int
+    {
+        return $this->_getData(self::QUOTE_ID) ?: null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setSessionId(string $sessionId): void
+    {
+        $this->setData(self::SESSION_ID, $sessionId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSessionId(): ?string
+    {
+        return $this->_getData(self::SESSION_ID);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setNonce(?string $nonce): void
+    {
+        $this->setData(self::NONCE, $nonce);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNonce(): ?string
+    {
+        return $this->_getData(self::NONCE);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setFingerprint(string $fingerprint): void
+    {
+        $this->setData(self::FINGERPRINT, $fingerprint);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFingerprint(): ?string
+    {
+        return $this->_getData(self::FINGERPRINT);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setFingerprintData(string $fingerprintData): void
+    {
+        $this->setData(self::FINGERPRINT_DATA, $fingerprintData);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFingerprintData(): ?string
+    {
+        return $this->_getData(self::FINGERPRINT_DATA);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCreatedAt(): ?string
+    {
+        return $this->_getData(self::CREATED_AT);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUpdatedAt(): ?string
+    {
+        return $this->_getData(self::UPDATED_AT);
+    }
+}

--- a/Model/ResourceModel/Payment/Intent.php
+++ b/Model/ResourceModel/Payment/Intent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Acquired.com Payments Integration for Magento2
+ *
+ * Copyright (c) 2024 Acquired Limited (https://acquired.com/)
+ *
+ * This file is open source under the MIT license.
+ * Please see LICENSE file for more details.
+ */
+
+namespace Acquired\Payments\Model\ResourceModel\Payment;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class Intent extends AbstractDb
+{
+    /**
+     * @inheritdoc
+     */
+    protected function _construct()
+    {
+        $this->_init('acquired_payment_intent', 'payment_intent_id');
+    }
+}

--- a/Model/ResourceModel/Payment/Intent/Collection.php
+++ b/Model/ResourceModel/Payment/Intent/Collection.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Acquired.com Payments Integration for Magento2
+ *
+ * Copyright (c) 2024 Acquired Limited (https://acquired.com/)
+ *
+ * This file is open source under the MIT license.
+ * Please see LICENSE file for more details.
+ */
+
+namespace Acquired\Payments\Model\ResourceModel\Payment\Intent;
+
+use Acquired\Payments\Model\Payment\Intent as Model;
+use Acquired\Payments\Model\ResourceModel\Payment\Intent as ResourceModel;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+class Collection extends AbstractCollection
+{
+    /**
+     * @var string
+     */
+    protected $_eventPrefix = 'acquired_payment_intent_collection';
+
+    /**
+     * @inheritdoc
+     */
+    protected function _construct()
+    {
+        $this->_init(Model::class, ResourceModel::class);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "acquired/module-payments",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Integration module for Acquired.com payment",
   "type": "magento2-module",
   "require": {

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -71,4 +71,25 @@
             onDelete="SET NULL"
         />
     </table>
+
+    <table name="acquired_payment_intent" resource="default" engine="innodb" comment="Acquired Payment Intent">
+        <column name="payment_intent_id" xsi:type="int" unsigned="true" nullable="false" identity="true"
+                comment="Payment Intent ID"/>
+        <column xsi:type="int" name="quote_id" unsigned="true" nullable="false" identity="false"
+                default="0" comment="Quote ID"/>
+        <column xsi:type="varchar" name="session_id" nullable="false" length="64" comment="Payment Session ID"/>
+        <column xsi:type="varchar" name="nonce" nullable="true" length="32" comment="Nonce String"/>
+        <column xsi:type="varchar" name="fingerprint" nullable="false" length="64" comment="Fingerprint String"/>
+        <column xsi:type="text" name="fingerprint_data" nullable="true" comment="Fingerprint Data"/>
+        <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Created At"/>
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
+                comment="Updated At"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="payment_intent_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="ACQUIRED_PAYMENT_INTENT_QUOTE_ID">
+            <column name="quote_id"/>
+        </constraint>
+    </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -30,5 +30,21 @@
         "constraint": {
             "PRIMARY": true
         }
+    },
+    "acquired_payment_intent": {
+        "column": {
+            "payment_intent_id": true,
+            "quote_id": true,
+            "session_id": true,
+            "nonce": true,
+            "fingerprint": true,
+            "fingerprint_data": true,
+            "created_at": true,
+            "updated_at": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "ACQUIRED_PAYMENT_INTENT_QUOTE_ID": true
+        }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,6 +19,7 @@
     <preference for="Acquired\Payments\Api\Data\MultishippingInterface" type="Acquired\Payments\Model\Multishipping"/>
     <preference for="Acquired\Payments\Api\Data\MultishippingSearchResultsInterface" type="Magento\Framework\Api\SearchResults"/>
     <preference for="Acquired\Payments\Api\Data\MultishippingResultInterface" type="Acquired\Payments\Model\Data\MultishippingResult"/>
+    <preference for="Acquired\Payments\Api\Data\PaymentIntentInterface" type="Acquired\Payments\Model\Payment\Intent"/>
 
     <type name="Acquired\Payments\Model\Api\AcquiredSession">
         <arguments>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,7 +10,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Acquired_Payments" setup_version="0.9.8">
+    <module name="Acquired_Payments" setup_version="1.0.2">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
- Introduce payment intent table to store payment intents from customers
- Remove saving nonce and session id values to checkout session
- Add saving nonce and session id as payment intents to separate database table

This feature will hopefully resolve issues where concurrent AJAX requests were previously resetting the value in the session regarding nonce and acquired session id.

It aims to do this by using database as a storage intents and naming it more aptly a payment intent from a customer related to a active quote they have.

This should be merged after FEAT-1.0.1 as it also increments the version of the module.