### PR TITLE
Fix issue with Apple Pay validation of 3DS

### DIFF
--- a/Gateway/Validator/RequestBuilderValidator.php
+++ b/Gateway/Validator/RequestBuilderValidator.php
@@ -67,7 +67,12 @@ class RequestBuilderValidator extends AbstractValidator
             throw new BuilderException(__('Order ID does not match.'));
         }
 
-        if($this->cardConfig->isTdsActive() && empty($paymentAdditionalData['multishipping'])) {
+        // in case of apple pay, the hash will not be in the response so we skip the validation
+        $shouldValidateHash = $this->cardConfig->isTdsActive() &&
+            empty($paymentAdditionalData['multishipping']) &&
+            !in_array($transaction[TransactionResponseInterface::PAYMENT_METHOD], ['apple_pay']);
+
+        if($shouldValidateHash) {
             if(empty($paymentAdditionalData['hash'])) {
                 throw new BuilderException(__('Hash is required for 3DS secure transactions.'));
             }


### PR DESCRIPTION
Removed hash validation for Apple Pay because on the frontend Acquired does not return hash in the response payload after confirming a Apple Pay transaction